### PR TITLE
tag support on website

### DIFF
--- a/pages/tags/[id].js
+++ b/pages/tags/[id].js
@@ -1,0 +1,15 @@
+import Head from 'next/head'
+import Layout, { name } from '../../components/layout'
+
+// TODO: get all posts with tag
+
+export default function Tag() {
+  return (
+    <Layout post>
+      <Head>
+        <title>Hello | {name}</title>
+      </Head>
+      <p>Hello World</p>
+    </Layout>
+  )
+}


### PR DESCRIPTION
- have a `/tags/TAG` website with list of all blog posts associated with it
- home page should display list of tags next to the blog post article and date
- ideally a drop down menu from header showing posts and tags